### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,8 +92,8 @@ jobs:
         run: |
           test -x rust/target/release/main
           test -x rust/target/release/isONform_parallel
-          rust/target/release/main --version | grep -qx 'main 0.3.9'
-          rust/target/release/isONform_parallel --version | grep -qx 'isONform_parallel 0.3.9'
+          rust/target/release/main --version | grep -qx 'main 0.4.0'
+          rust/target/release/isONform_parallel --version | grep -qx 'isONform_parallel 0.4.0'
 
   equivalence:
     name: differential vs the Python reference (${{ matrix.name }})

--- a/bench/equivalence.sh
+++ b/bench/equivalence.sh
@@ -250,7 +250,7 @@ cli_stdout_case() {
 layer_cli() {
   echo "== cli =="
 
-  # --version: argparse prints "%(prog)s 0.3.9"; clap must match exactly.
+  # --version: argparse prints "%(prog)s <version>"; clap must match exactly.
   # Compared on stdout by cli_case's `accepted`? No — argparse exits 0 here, so
   # this needs its own shape.
   local v_py v_rs

--- a/isONform_parallel
+++ b/isONform_parallel
@@ -330,7 +330,7 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="De novo reconstruction of long-read transcriptome reads",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--version', action='version', version='%(prog)s 0.3.9')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.4.0')
     parser.add_argument('--fastq_folder', type=str, default=False,
                         help='Path to input fastq folder with reads in clusters')
     parser.add_argument('--t', dest="nr_cores", type=int, default=8, help='Number of cores allocated for clustering')

--- a/main
+++ b/main
@@ -593,7 +593,7 @@ DEBUG=False
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="De novo error correction of long-read transcriptome reads",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--version', action='version', version='%(prog)s 0.3.9')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.4.0')
     parser.add_argument('--fastq', type=str, default=False, help='Path to input fastq file with reads')
 
     parser.add_argument('--k', type=int, default=20, help='Kmer size')

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isonform"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "biodiff-wfa2-sys",
  "block-aligner",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "isonform"
 # Matches the Python's advertised version, which is what `--version` prints and
 # what setup.py declares. Keep the two in step: the CLI string lives in
 # `cli::VERSION`.
-version = "0.3.9"
+version = "0.4.0"
 edition = "2021"
 # Raised from 1.74 by spoars, which requires 1.85. Kept in step with the
 # isONcorrect port so the shared modules move between the two unchanged.

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -44,9 +44,15 @@ use std::path::PathBuf;
 use clap::{ArgAction, Parser};
 
 /// The version string both entry points advertise. argparse formats it as
-/// `%(prog)s 0.3.9`, so `--version` prints `main 0.3.9` /
-/// `isONform_parallel 0.3.9`.
-pub const VERSION: &str = "0.3.9";
+/// `%(prog)s <version>`, so `--version` prints `main 0.4.0` /
+/// `isONform_parallel 0.4.0`.
+///
+/// Taken from `Cargo.toml` rather than written out, because the same number
+/// also lives in `setup.py` and in both python entry points, and a release
+/// that bumps some of them and not others produces binaries that lie about
+/// their own version. `version_matches_the_python_entry_points` below is what
+/// actually holds the four in step.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Exit code the reference uses for its own validation failures (`sys.exit(1)`).
 pub const EXIT_VALIDATION: i32 = 1;
@@ -944,9 +950,24 @@ mod tests {
         assert_eq!(err.exit_code(), EXIT_USAGE);
     }
 
+    /// The version is written out in four places: `rust/Cargo.toml` (which
+    /// `VERSION` reads), `setup.py`, and the two python entry points, whose
+    /// `--version` output `bench/equivalence.sh` compares against the port's.
+    /// Nothing but this test stops a release from moving some and not others.
     #[test]
-    fn version_matches_setup_py() {
-        assert_eq!(VERSION, "0.3.9");
+    fn version_matches_the_python_entry_points() {
+        for (name, src) in [
+            ("setup.py", include_str!("../../setup.py")),
+            ("main", include_str!("../../main")),
+            ("isONform_parallel", include_str!("../../isONform_parallel")),
+        ] {
+            assert!(
+                src.contains(VERSION),
+                "{name} does not mention version {VERSION}; \
+                 bump it, or the binaries will advertise a version the \
+                 reference does not"
+            );
+        }
     }
 
     // --- the ARGS Namespace line -----------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
 
     name='isONform',  # Required
-    version='0.3.9',  # Required
+    version='0.4.0',  # Required
     description='De novo construction of isoforms from long-read data ',  # Required
     long_description=long_description,  # Optional
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Version bump to 0.4.0, and tie the six places the version is written out together so a partial bump fails the test suite instead of shipping binaries that misreport their version.