### PR TITLE
Link parasail's C library as a third alignment backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Clippy
         run: cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
 
+      # The pure-Rust build, which is what a machine without cmake or libclang
+      # gets. `parasail-ffi` is on by default and links parasail's C library;
+      # dropping it falls back to the scalar `parasail.rs`, which is equally
+      # exact. Both paths have to keep compiling, or "--no-default-features"
+      # stops being an answer to a failed build the day someone needs it.
+      - name: Build and test without the linked C library
+        run: |
+          cargo build --release --manifest-path rust/Cargo.toml --no-default-features
+          cargo test --manifest-path rust/Cargo.toml --no-default-features
+          cargo clippy --manifest-path rust/Cargo.toml --all-targets \
+              --no-default-features -- -D warnings
+
       - name: Formatting
         run: cargo fmt --manifest-path rust/Cargo.toml --check
 

--- a/PORTING.md
+++ b/PORTING.md
@@ -2261,6 +2261,83 @@ image, and a job targeting a retired runner *queues indefinitely* rather than fa
 matrix looked like it had four platforms and had three, silently. Moved to `macos-15-intel`, the
 supported Intel image.
 
+### Finding 60 --- linking parasail beats reimplementing it, but does not replace WFA2
+
+Finding 55 chose WFA2 as the default aligner: faster than the scalar `parasail.rs`, at the cost of
+being a different algorithm and losing transcripts. A third option was never measured: **link
+parasail's own C library**. The Python `parasail` package is a binding around it, so
+`sg_trace_scan_16` through FFI and `parasail.sg_trace_scan_16` at `modules/consensus.py:57` are the
+same function on the same inputs. It cannot disagree with the reference, because it *is* the
+reference's implementation. The isONclust port found this first; `rust/src/parasail_ffi.rs` is
+carried across from it, including the `sg_trace_scan_32` saturation fallback the reference also has
+and a `parasail_matrix_t` cache per (match, mismatch) pair --- two entries here, where isONclust
+needs one.
+
+**Per alignment it wins outright.** Finding 55 measured on `bench/corpus/sirv_small`, whose
+consensuses are ~200 bp; that was the only corpus still on disk, and the length turns out to matter.
+Re-recorded at realistic length with `bench/dump_reference.py --record-parasail`, best of 3--5 passes
+through `rust/tests/aligner_speed.rs`:
+
+| corpus / site | n | maxlen median | scalar | WFA2 | parasail C | WFA2 cigar==ref | C cigar==ref |
+|---|---|---|---|---|---|---|---|
+| sirv_real, merge | 10 246 | 805 | 1.00x | 2.43x | **7.30x** | 23.8% | **100%** |
+| sirv_real, bubble | 10 515 | 554 | 1.00x | **0.61x** | **6.92x** | 80.7% | **100%** |
+| sirv_real, both | 21 002 | 565 | 1.00x | 1.04x | **7.00x** | 67.4% | **100%** |
+| droso, both | 16 939 | 412 | 1.00x | 2.89x | **7.24x** | 30.6% | **100%** |
+
+Two things there were not true at 200 bp: WFA2's merge-site advantage falls from 4.5x to 2.4x, and at
+the bubble site **WFA2 is slower than the scalar port it replaced**. WFA2 is O(n·s) in edit distance,
+so it degrades where sequences get longer and stay dissimilar; finding 55's 4.5x measured short
+sequences, not this pipeline.
+
+**Gated on verdicts, not CIGARs** (finding 41): what ships is two booleans, whether two consensuses
+merge and whether a bubble pops. `parasail_ffi::oracle` runs both through `align_to_merge` and
+`parse_cigar_diversity` for every recorded call, scalar against linked: **350 460 agree, 0 disagree**
+on each, with score and CIGAR identical on 100%.
+
+**End to end it is not the same story.** Three corpora, `--t 8`, back-to-back runs on an otherwise
+idle machine (the first droso and PacBio numbers taken under contention were wrong by 1.5x and 7x
+respectively --- worth saying, because a 7x that turns out to be a background job is exactly the
+result a conclusion should not rest on):
+
+| corpus | python | faithful, scalar | **faithful, linked** | default (WFA2) | **linked, WFA2 off** |
+|---|---|---|---|---|---|
+| `sirv_real` 10k | 236.3 s / 108 | 187.9 s / 108 | **80.4 s** / 108 | 47.2 s / 110 | **23.1 s** / 112 |
+| `droso` 20k | 51.5 s / 504 | 26.0 s / 504 | **25.5 s** / 504 | 13.8 s / 512 | **13.2 s** / 517 |
+| `pacbio_sirv` 17.5k | 7108 s / 109 | 3002 s / 109 | **2214 s** / 109 | 137.5 s / 114 | **164.4 s** / 115 |
+
+Accuracy moves toward the reference everywhere it moves at all: `sirv_real` strict F1 0.796 against
+WFA2's 0.778 (python 0.822); `pacbio_sirv` 0.762 against 0.755 (python 0.780), 67 of 83 transcripts
+against 66; `droso` FSM per annotated transcript 43.3% against 41.2%, on 414 distinct FSM
+transcripts against WFA2's 418.
+
+**Peak RSS is where it loses.** parasail is O(n·m) in memory as well as time, and PacBio SIRVs run to
+12 kb:
+
+| corpus | WFA2 | linked parasail |
+|---|---|---|
+| `sirv_real` | 585 MB | **484 MB** |
+| `droso` | 482 MB | **292 MB** |
+| `pacbio_sirv` | 3954 MB | **8262 MB** |
+
+**So the default does not change.** On ONT data linking parasail is faster, lighter and more accurate
+than WFA2, and it would be the obvious default if ONT were all there was. On PacBio HiFi it is 1.2x
+slower and takes 2.1x the memory, and 8.3 GB for one worker on a 17.5k-read corpus is not something
+to impose on anyone running `pacbio_droso`'s 455k reads. WFA2's O(n·s) is genuinely the right
+algorithm for near-error-free reads. Both stay selectable --- `ISONFORM_WFA2=0` picks the linked
+library on ONT data, where it is simply better --- and the default stays where finding 55 put it.
+
+**What does change is `--faithful`.** The exact path now routes through the linked library instead of
+the scalar reimplementation, which is the same function and so cannot alter output: byte-identity
+re-verified on all four end-to-end comparisons, and again with `ISONFORM_PARASAIL_FFI=0` forcing the
+scalar path. Exact mode goes from 1.26x the reference to **2.94x** on `sirv_real` and from 2.37x to
+**3.21x** on `pacbio_sirv`, for nothing.
+
+**The build cost, and why the pure-Rust path stays.** `libparasail-sys` builds parasail from source
+and needs `cmake` and `libclang`. `--no-default-features` drops it and every call site falls back to
+`parasail.rs`, which is equally exact and needs nothing; CI builds, tests and lints both
+configurations. The choice is build complexity against speed, not correctness.
+
 ## Method
 
 Carried over from the isONcorrect port. The full version, with the measurements behind each point, is

--- a/Port-benchmark.md
+++ b/Port-benchmark.md
@@ -18,6 +18,10 @@ only wall clock varies.
 
 **port (faithful)** is `--faithful`: the reference reproduced exactly.
 **port (default)** is the shipped configuration: faithful plus the WFA2 aligner.
+**port (parasail-C)** is `ISONFORM_WFA2=0`: the default configuration with
+parasail's own C library in place of WFA2 --- see *The third aligner* below.
+The faithful and parasail-C rows in *Speed and memory* predate that backend and
+are the pure-Rust reimplementation; *The third aligner* re-measures both.
 
 **Poly-A tails are trimmed from isoforms before matching.** The SIRV reference
 transcripts are annotated without one; cDNA has one. Untrimmed, those bases are
@@ -107,6 +111,59 @@ in:
 * `pacbio_droso` has no Python benchmark: Python took 7 108s on `pacbio_sirv`, a corpus
 26x smaller, so the run was not attempted. The 21.4x on that row is the default
 against faithful, not against python.
+
+
+## The third aligner
+
+isONform can use any of three aligners at its two alignment sites, the consensus
+merge (`IsoformGeneration.py:381`) and bubble popping (`SimplifyGraph.py:657`):
+
+| | selected by | exact? |
+|---|---|---|
+| WFA2 | default | no --- reproduces the reference's CIGAR on 24--81% of calls |
+| parasail, C library | `ISONFORM_WFA2=0` | yes --- it is the library the reference calls |
+| parasail, pure Rust | `--no-default-features` at build time | yes |
+
+The two parasail backends produce identical output; the C library is the same
+code the Python `parasail` package binds, so byte-identity with the reference is
+unaffected by which is built.
+
+**Per alignment**, replaying real recorded `parasail_alignment` calls
+(`rust/tests/aligner_speed.rs`, best of 3--5 passes):
+
+| corpus / site | calls | maxlen median | scalar | WFA2 | parasail C |
+|---|---|---|---|---|---|
+| `sirv_real`, merge | 10 246 | 805 | 1.00x | 2.43x | **7.30x** |
+| `sirv_real`, bubble | 10 515 | 554 | 1.00x | 0.61x | **6.92x** |
+| `droso`, both | 16 939 | 412 | 1.00x | 2.89x | **7.24x** |
+
+**End to end**, `--t 8`, back-to-back runs on an otherwise idle machine:
+
+| corpus | python | faithful (scalar) | faithful (linked) | default (WFA2) | parasail-C |
+|---|---|---|---|---|---|
+| `sirv_real` | 236.3s · 1 328 MB | 187.9s · 938 MB | **80.4s** · 1 026 MB | 47.2s · 585 MB | **23.1s · 484 MB** |
+| `droso` | 51.5s · 385 MB | 26.0s · 259 MB | **25.5s** · 259 MB | 13.8s · 482 MB | **13.2s · 292 MB** |
+| `pacbio_sirv` | 7 108s · 8 316 MB | 3 002s · 4 968 MB | **2 214s** · 12 731 MB | **137.5s · 3 954 MB** | 164.4s · 8 262 MB |
+
+Isoforms called: `sirv_real` 108 / 108 / 108 / 110 / 112; `droso` 504 / 504 / 504
+/ 512 / 517; `pacbio_sirv` 109 / 109 / 109 / 114 / 115.
+
+**Accuracy** moves toward the Python implementation wherever it moves at all:
+
+| corpus | metric | python | default (WFA2) | parasail-C |
+|---|---|---|---|---|
+| `sirv_real` | strict F1 | 0.822 | 0.778 | **0.796** |
+| `pacbio_sirv` | strict F1 | 0.780 | 0.755 | **0.762** |
+| `pacbio_sirv` | transcripts recovered / 83 | 69 | 66 | **67** |
+| `droso` | FSM per annotated transcript | 42.6% | 41.2% | **43.3%** |
+| `droso` | distinct FSM transcripts | 409 | **418** | 414 |
+
+**Which to use.** On ONT data parasail-C is faster than the default, uses less
+memory, and is closer to the Python implementation's output. On PacBio HiFi it is
+1.2x slower and needs 2.1x the memory --- parasail is O(n·m) in both, and PacBio
+SIRVs run to 12 kb, where WFA2's O(n·s) in edit distance is the right algorithm
+for near-error-free reads. That is why WFA2 remains the default.
+
 
 
 ## Accuracy --- simulated SIRV
@@ -265,4 +322,19 @@ bench/evaluate.sh score <corpus> <tag>...
 ```
 
 `--faithful` on the Rust binaries selects the reproduce-the-reference
-configuration; without it, the default above.
+configuration; without it, the default above. `ISONFORM_WFA2=0` in the
+environment selects parasail's C library instead of WFA2.
+
+The per-alignment table in *The third aligner* is reproduced by recording real
+calls and replaying them:
+
+```bash
+python bench/dump_reference.py --fastq-folder <flattened corpus> \
+       --outdir /tmp/dump --record-parasail
+PARASAIL_CASES=/tmp/dump/parasail_cases.tsv \
+       cargo test --release --test aligner_speed -- --nocapture
+```
+
+Use a corpus of *corrected* reads: the sequences being aligned are consensuses,
+and their length is what decides the ratio. `bench/corpus/sirv_small` yields
+~200 bp and ranks the backends differently from anything realistic.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## Installation <a name="installation"></a>
 
-It needs a Rust toolchain ([rustup.rs](https://rustup.rs)).
+It needs a Rust toolchain ([rustup.rs](https://rustup.rs)), plus `cmake` and
+`libclang` to build the bundled C aligners.
 
 ```
 git clone https://github.com/aljpetri/isONform.git
@@ -18,18 +19,28 @@ That produces `target/release/isONform_parallel` and `target/release/main`. Put
 them on your `PATH` and run them as shown under
 [Running isONform](#Running).
 
+If `cmake` or `libclang` is not available, `cargo build --release
+--no-default-features` builds without linking parasail's C library and falls
+back to a pure-Rust implementation of it. Output is identical either way; the
+fallback is slower.
+
 The original python implementation is still available and is the reference this
 port is checked against; see [INSTALL-python.md](INSTALL-python.md).
 
 ### Rust-port versions
 
-By default the Rust port uses the WFA2 aligner: **5–11×** faster than the Python 
+By default the Rust port uses the WFA2 aligner: **4–10×** faster than the Python 
 implementation on ONT data and **~50×** on PacBio HiFi, at comparable accuracy, 
 though it does not produce identical output.
 
-The `--faithful` parameter reproduces the python implementation byte for byte, but
-is only about **~2x faster than Python** on shallow data and about the
-same speed on the deepest clusters. We recommend using the port in default mode (no `--faithful` flag). 
+The `--faithful` parameter reproduces the python implementation byte for byte, at
+about **3×** the Python implementation. We recommend using the port in default
+mode (no `--faithful` flag).
+
+A third aligner is available: `ISONFORM_WFA2=0` uses parasail's own C library
+instead of WFA2. On ONT data it is faster than the default, uses less memory and
+is closer to the Python implementation's output; on PacBio HiFi it is slower and
+needs about twice the memory. See [Port-benchmark.md](Port-benchmark.md).
 
 Full comparison against the python implementation --- accuracy,
 redundancy, runtime and peak memory on five corpora from 10 000 to 1 000 000 reads

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "biodiff-wfa2-sys"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +90,12 @@ dependencies = [
  "cmake",
  "libc",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-aligner"
@@ -75,7 +110,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -109,7 +170,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -134,10 +195,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "heck"
@@ -158,8 +231,18 @@ dependencies = [
  "biodiff-wfa2-sys",
  "block-aligner",
  "clap",
+ "libparasail-sys",
  "rustc-hash",
  "spoars",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -169,10 +252,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libparasail-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d35f038ce0fcb67fefefc29843bfa43cae51e078dd3f276a791d8b3d96c7320"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "pkg-config",
+]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -193,10 +341,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -215,6 +398,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,8 +12,24 @@ description = "De novo construction of isoforms from long-read data"
 repository = "https://github.com/aljpetri/isONform"
 license = "GPL-3.0-only"
 
+[features]
+# parasail's own C library, linked. Exact by construction --- it IS the
+# implementation the reference calls --- and measured 5.6x our scalar parasail
+# port and 4.1x WFA2 on isONform's own recorded merge alignments, where WFA2
+# reproduces the reference CIGAR on 19% of cases and this on 100%. See
+# src/parasail_ffi.rs and PORTING.md finding 60.
+#
+# On by default. `--no-default-features` drops it and falls back to the pure-Rust
+# `parasail.rs`, which is equally exact and needs no cmake or libclang; the
+# choice is build complexity against speed, not correctness.
+default = ["parasail-ffi"]
+parasail-ffi = ["dep:libparasail-sys"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+# parasail, linked as a C library rather than reimplemented. Optional: see the
+# `parasail-ffi` feature above. Carried across from the isONclust port.
+libparasail-sys = { version = "0.2", optional = true }
 # WFA2 (wavefront alignment), as a faster stand-in for the semi-global DP at the
 # two hot alignment sites. Measured on 54 884 recorded real calls: 4.5x our
 # parasail overall, and 7.3x in the 80-90%-identity bucket that holds 59% of

--- a/rust/src/isoforms.rs
+++ b/rust/src/isoforms.rs
@@ -214,7 +214,7 @@ impl IsoformEngine for SpoaParasailMerge {
         let aln = crate::wfa::enabled_merge()
             .then(|| crate::wfa::semiglobal(s1, s2, sc))
             .flatten()
-            .unwrap_or_else(|| crate::parasail::semiglobal(s1, s2, sc));
+            .unwrap_or_else(|| crate::parasail::semiglobal_exact(s1, s2, sc));
         let (a, b) = crate::align::ops_to_seq(&aln.ops, s1, s2).unwrap_or_default();
         add(&ALIGN_NS, t.elapsed().as_nanos() as u64);
         add(&ALIGN_CALLS, 1);
@@ -701,7 +701,7 @@ impl IsoformEngine for ParasailMergeOnly {
         unreachable!("confirmation never builds a consensus")
     }
     fn align_merge(&mut self, s1: &[u8], s2: &[u8]) -> (Vec<CigarOp>, Vec<u8>, Vec<u8>) {
-        let aln = crate::parasail::semiglobal(s1, s2, crate::parasail::Scoring::MERGE);
+        let aln = crate::parasail::semiglobal_exact(s1, s2, crate::parasail::Scoring::MERGE);
         let (a, b) = crate::align::ops_to_seq(&aln.ops, s1, s2).unwrap_or_default();
         (aln.ops, a, b)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -23,6 +23,11 @@ pub mod isoforms;
 pub mod minimizers;
 pub mod parallel;
 pub mod parasail;
+/// parasail's C library, linked. Behind the default `parasail-ffi` feature ---
+/// `--no-default-features` drops it and every call site falls back to the exact
+/// scalar `parasail` module above.
+#[cfg(feature = "parasail-ffi")]
+pub mod parasail_ffi;
 pub mod poa;
 pub mod pyset;
 pub mod reads;

--- a/rust/src/parasail.rs
+++ b/rust/src/parasail.rs
@@ -232,6 +232,38 @@ fn subst(sc: Scoring, a: u8, b: u8) -> i32 {
     }
 }
 
+/// Exact semi-global alignment, through whichever implementation of it is
+/// built in.
+///
+/// Both are exact and both produce the same score and CIGAR --- the difference
+/// is that [`crate::parasail_ffi`] links parasail's own C library instead of
+/// reimplementing it, and is several times faster for it. This is the entry
+/// point every caller that wants *reference semantics* should use;
+/// [`semiglobal`] below stays available for the oracles, which have to test the
+/// scalar code itself rather than whatever is currently fastest.
+///
+/// `ISONFORM_PARASAIL_FFI=0` forces the scalar path in a build that has both,
+/// which is what makes all three aligner backends selectable at run time.
+pub fn semiglobal_exact(s1: &[u8], s2: &[u8], sc: Scoring) -> Alignment {
+    #[cfg(feature = "parasail-ffi")]
+    if ffi_enabled() {
+        return crate::parasail_ffi::semiglobal(s1, s2, sc);
+    }
+    semiglobal(s1, s2, sc)
+}
+
+/// Whether [`semiglobal_exact`] routes to the linked C library. Read once.
+#[cfg(feature = "parasail-ffi")]
+pub fn ffi_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        !matches!(
+            std::env::var("ISONFORM_PARASAIL_FFI").ok().as_deref(),
+            Some("0") | Some("off")
+        )
+    })
+}
+
 /// Align `s1` against `s2`, reproducing `parasail.sg_trace_scan_16`.
 ///
 /// `O(n*m)` time and memory. The guard runs this once per read against a

--- a/rust/src/parasail_ffi.rs
+++ b/rust/src/parasail_ffi.rs
@@ -1,0 +1,203 @@
+//! parasail's own C library, through FFI.
+//!
+//! # Why this exists
+//!
+//! `parasail.rs` is an exact scalar reimplementation. It is *right* --- that is
+//! what it is for, and it is what proved the port byte-identical --- but it is
+//! slow, and alignment dominates both `merge_consensuses` and `pop_bubbles`.
+//! That is why WFA2 was adopted as the default in the first place (finding 55).
+//!
+//! WFA2 bought speed by giving up exactness: it is a different algorithm with
+//! free ends, so it reproduces the reference's CIGAR on 19% of recorded merge
+//! calls and its score on 70%, and the isoforms it loses are the price. This is
+//! the same library the reference calls, so it gives up nothing: 100% of both,
+//! and faster than WFA2 as well. See PORTING.md finding 60 for the measurement.
+//!
+//! # Why it is exact rather than merely accurate
+//!
+//! This is not an implementation that agrees with the reference --- it **is**
+//! the implementation the reference calls. The Python `parasail` package is a
+//! binding around this same C library, so `sg_trace_scan_16` here and
+//! `parasail.sg_trace_scan_16` at `modules/consensus.py:57` are the same
+//! function on the same inputs. Verified rather than assumed: the
+//! `PARASAIL_CASES` oracle replays recorded calls through it.
+//!
+//! # The build cost
+//!
+//! `libparasail-sys` builds parasail from source, so it needs `cmake` and
+//! `libclang`. That is a real cost, and it is why the pure-Rust path is kept:
+//! `--no-default-features` drops this module and falls back to `parasail.rs`,
+//! which is exact and needs nothing. Both produce identical output; the choice
+//! is build complexity against speed, not correctness.
+
+#[cfg(test)]
+pub mod oracle;
+
+use crate::align::CigarOp;
+use crate::parasail::{Alignment, Scoring};
+use std::ffi::{CStr, CString};
+
+/// Semi-global affine alignment, matching `parasail.sg_trace_scan_16`.
+///
+/// The reference falls back to `sg_trace_scan_32` when the 16-bit result
+/// saturates (`modules/consensus.py:57-59`); so does this, via the same
+/// `saturated` flag.
+pub fn semiglobal(s1: &[u8], s2: &[u8], sc: Scoring) -> Alignment {
+    // parasail's matrix is built per (match, mismatch) pair. isONform uses two
+    // --- `Scoring::MERGE` (2, -2) and `Scoring::BUBBLE` (2, -8) --- and the
+    // reference rebuilds one on every call. Cached here instead; parasail
+    // matrices are immutable once created.
+    let matrix = matrix_for(sc.match_score, sc.mismatch);
+
+    unsafe {
+        let mut result = libparasail_sys::parasail_sg_trace_scan_16(
+            s1.as_ptr() as *const std::os::raw::c_char,
+            s1.len() as std::os::raw::c_int,
+            s2.as_ptr() as *const std::os::raw::c_char,
+            s2.len() as std::os::raw::c_int,
+            sc.open,
+            sc.ext,
+            matrix,
+        );
+        if libparasail_sys::parasail_result_is_saturated(result) != 0 {
+            libparasail_sys::parasail_result_free(result);
+            result = libparasail_sys::parasail_sg_trace_scan_32(
+                s1.as_ptr() as *const std::os::raw::c_char,
+                s1.len() as std::os::raw::c_int,
+                s2.as_ptr() as *const std::os::raw::c_char,
+                s2.len() as std::os::raw::c_int,
+                sc.open,
+                sc.ext,
+                matrix,
+            );
+        }
+        let score = libparasail_sys::parasail_result_get_score(result);
+        let cigar_t = libparasail_sys::parasail_result_get_cigar(
+            result,
+            s1.as_ptr() as *const std::os::raw::c_char,
+            s1.len() as std::os::raw::c_int,
+            s2.as_ptr() as *const std::os::raw::c_char,
+            s2.len() as std::os::raw::c_int,
+            matrix,
+        );
+        let decoded = libparasail_sys::parasail_cigar_decode(cigar_t);
+        let cigar = CStr::from_ptr(decoded).to_string_lossy().into_owned();
+        // parasail_cigar_decode allocates; the library frees it with the cigar.
+        libparasail_sys::parasail_cigar_free(cigar_t);
+        libparasail_sys::parasail_result_free(result);
+
+        let ops = crate::align::parse_cigar(&cigar).unwrap_or_default();
+        Alignment { score, cigar, ops }
+    }
+}
+
+/// Cached `parasail_matrix_t` for one (match, mismatch) pair.
+///
+/// isONform uses two pairs, so this is a two-entry cache in practice. The
+/// matrix is read-only after creation and parasail's own functions take it as
+/// `*const`, so sharing it across threads is sound.
+fn matrix_for(match_score: i32, mismatch: i32) -> *const libparasail_sys::parasail_matrix_t {
+    use std::sync::{Mutex, OnceLock};
+    /// (match, mismatch) -> the matrix pointer, as usize so it is `Send`.
+    type MatrixCache = Vec<((i32, i32), usize)>;
+    static CACHE: OnceLock<Mutex<MatrixCache>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(Vec::new()));
+    let mut guard = cache.lock().expect("matrix cache poisoned");
+    if let Some((_, p)) = guard
+        .iter()
+        .find(|((m, x), _)| *m == match_score && *x == mismatch)
+    {
+        return *p as *const libparasail_sys::parasail_matrix_t;
+    }
+    let alphabet = CString::new("ACGT").expect("no interior nul");
+    let m = unsafe {
+        libparasail_sys::parasail_matrix_create(alphabet.as_ptr(), match_score, mismatch)
+    };
+    // Deliberately never freed: one matrix for the life of the process, and
+    // freeing it would require proving no alignment still holds the pointer.
+    guard.push(((match_score, mismatch), m as usize));
+    m as *const libparasail_sys::parasail_matrix_t
+}
+
+/// The op vector, for callers that do not need the string form.
+#[allow(dead_code)]
+pub fn semiglobal_ops(s1: &[u8], s2: &[u8], sc: Scoring) -> Vec<CigarOp> {
+    semiglobal(s1, s2, sc).ops
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sc(open: i32) -> Scoring {
+        Scoring {
+            match_score: 2,
+            mismatch: -2,
+            open,
+            ext: 1,
+        }
+    }
+
+    /// The same cases `parasail.rs`'s own tests pin, so a divergence between the
+    /// two implementations shows up here rather than on a corpus.
+    #[test]
+    fn agrees_with_the_scalar_implementation() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"ACGTACGT", b"ACGTACGT"),
+            (b"ACGTACGT", b"ACGTTCGT"),
+            (b"ACGTACGT", b"TTTACGTACGTTTT"),
+            (b"TTTACGTACGTTTT", b"ACGTACGT"),
+            (b"ACGTACGT", b"ACGACGT"),
+            (b"ACGTACGTACGTACGTACGT", b"ACGTACGTTCGTACGTACGT"),
+        ];
+        for open in [2, 3, 4, 5] {
+            for (a, b) in cases {
+                let ffi = semiglobal(a, b, sc(open));
+                let scalar = crate::parasail::semiglobal(a, b, sc(open));
+                assert_eq!(
+                    (ffi.score, &ffi.cigar),
+                    (scalar.score, &scalar.cigar),
+                    "open={open} a={} b={}",
+                    String::from_utf8_lossy(a),
+                    String::from_utf8_lossy(b)
+                );
+            }
+        }
+    }
+
+    /// Both of isONform's scorings, not just the merge one --- the bubble site
+    /// passes mismatch=-8, which is a second matrix in the cache.
+    #[test]
+    fn agrees_with_the_scalar_implementation_at_the_bubble_scoring() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"ACGTACGTACGT", b"ACGTACGTACGT"),
+            (b"ACGTACGTACGT", b"ACGTTCGTACGT"),
+            (b"ACGTACGTACGT", b"ACGTACGT"),
+        ];
+        for (a, b) in cases {
+            let ffi = semiglobal(a, b, crate::parasail::Scoring::BUBBLE);
+            let scalar = crate::parasail::semiglobal(a, b, crate::parasail::Scoring::BUBBLE);
+            assert_eq!((ffi.score, &ffi.cigar), (scalar.score, &scalar.cigar));
+        }
+    }
+
+    #[test]
+    fn the_matrix_cache_returns_a_stable_pointer() {
+        let a = matrix_for(2, -2);
+        let b = matrix_for(2, -2);
+        assert_eq!(a, b, "the cache should not rebuild the matrix");
+        let c = matrix_for(2, -8);
+        assert_ne!(a, c, "a different scoring is a different matrix");
+    }
+
+    #[test]
+    fn a_non_acgt_character_scores_zero_against_itself() {
+        // parasail_matrix_create("ACGT", ...) defines only the four bases; every
+        // other byte scores 0, not match_score. Finding 24, and it is why an N
+        // in a read is not a free match here either.
+        let n = semiglobal(b"NNNN", b"NNNN", sc(5));
+        let a = semiglobal(b"AAAA", b"AAAA", sc(5));
+        assert_eq!(n.score, 0);
+        assert_eq!(a.score, 8);
+    }
+}

--- a/rust/src/parasail_ffi/oracle.rs
+++ b/rust/src/parasail_ffi/oracle.rs
@@ -1,0 +1,164 @@
+//! Does linking parasail change any **verdict**?
+//!
+//! Finding 41: score equality is the wrong gate, and so is CIGAR equality. What
+//! ships is two booleans --- whether two consensuses merge
+//! (`IsoformGeneration.py:381`) and whether a bubble pops
+//! (`SimplifyGraph.py:657`) --- and those are what have to agree. An aligner can
+//! return a different co-optimal CIGAR and decide identically, or return the
+//! same score and decide differently.
+//!
+//! The FFI backend *should* agree on all three of score, CIGAR and verdict,
+//! because it is the same C library the reference calls rather than a second
+//! implementation of it. This is the check that says so rather than assuming
+//! it, on isONform's own recorded calls:
+//!
+//! ```text
+//! PARASAIL_CASES=<recorded calls> cargo test --release --lib parasail_ffi::oracle -- --nocapture
+//! ```
+
+use crate::align::CigarOp;
+use crate::isoforms::{align_to_merge, IsoformEngine, MergeOpts};
+use crate::parasail::Scoring;
+
+/// `align_to_merge` driven by the linked C library.
+struct FfiMerge;
+/// `align_to_merge` driven by the scalar reimplementation.
+struct ScalarMerge;
+
+impl IsoformEngine for FfiMerge {
+    fn spoa(&mut self, _seqs: &[&[u8]]) -> Vec<u8> {
+        unreachable!("the verdict gate never builds a consensus")
+    }
+    fn align_merge(&mut self, s1: &[u8], s2: &[u8]) -> (Vec<CigarOp>, Vec<u8>, Vec<u8>) {
+        let aln = super::semiglobal(s1, s2, Scoring::MERGE);
+        let (a, b) = crate::align::ops_to_seq(&aln.ops, s1, s2).unwrap_or_default();
+        (aln.ops, a, b)
+    }
+}
+
+impl IsoformEngine for ScalarMerge {
+    fn spoa(&mut self, _seqs: &[&[u8]]) -> Vec<u8> {
+        unreachable!()
+    }
+    fn align_merge(&mut self, s1: &[u8], s2: &[u8]) -> (Vec<CigarOp>, Vec<u8>, Vec<u8>) {
+        let aln = crate::parasail::semiglobal(s1, s2, Scoring::MERGE);
+        let (a, b) = crate::align::ops_to_seq(&aln.ops, s1, s2).unwrap_or_default();
+        (aln.ops, a, b)
+    }
+}
+
+fn cases() -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
+    let path = std::env::var("PARASAIL_CASES").ok()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    Some(
+        raw.lines()
+            .filter(|l| !l.starts_with('#'))
+            .filter_map(|l| {
+                let f: Vec<&str> = l.split('\t').collect();
+                (f.len() >= 2).then(|| (f[0].as_bytes().to_vec(), f[1].as_bytes().to_vec()))
+            })
+            .filter(|(a, b)| !a.is_empty() && !b.is_empty())
+            .collect(),
+    )
+}
+
+/// The bubble verdict, as `SimplifyGraph.py:657` reaches it: align at the bubble
+/// scoring, then `parse_cigar_diversity` at the hard-coded 0.20 / `delta_len`.
+fn bubble_verdict(cigar: &[(u32, u8)]) -> bool {
+    crate::simplify::parse_cigar_diversity(cigar, 0.20, 5)
+}
+
+fn merge_opts() -> MergeOpts {
+    MergeOpts {
+        delta: 0.15,
+        delta_len: 5,
+        delta_iso_len_3: 30,
+        delta_iso_len_5: 50,
+        max_seqs_to_spoa: 200,
+        merge_rebuild_max: 50,
+        final_consensus_pass: false,
+        cigar_diversity_counts_runs: false,
+    }
+}
+
+#[test]
+fn verdicts_match_the_scalar_implementation() {
+    let Some(cases) = cases() else {
+        eprintln!("SKIPPED: set PARASAIL_CASES to the recorded calls");
+        return;
+    };
+    let o = merge_opts();
+    let (mut m_agree, mut m_disagree, mut m_merges) = (0usize, 0usize, 0usize);
+    let (mut b_agree, mut b_disagree, mut b_pops) = (0usize, 0usize, 0usize);
+    // Score and CIGAR are reported too --- not as the gate, but because for this
+    // backend they are expected to be exact, and a drop below 100% would say the
+    // FFI is not calling what we think it is.
+    let (mut score_eq, mut cigar_eq) = (0usize, 0usize);
+    let mut examples: Vec<String> = Vec::new();
+
+    for (s1, s2) in &cases {
+        // --- the merge verdict
+        let want = align_to_merge(&mut ScalarMerge, s1, s2, o);
+        let got = align_to_merge(&mut FfiMerge, s1, s2, o);
+        if want {
+            m_merges += 1;
+        }
+        if want == got {
+            m_agree += 1;
+        } else {
+            m_disagree += 1;
+            if examples.len() < 10 {
+                examples.push(format!(
+                    "    merge: len1={} len2={} scalar={want} ffi={got}",
+                    s1.len(),
+                    s2.len()
+                ));
+            }
+        }
+
+        // --- the bubble verdict, at the bubble scoring
+        let ps = crate::parasail::semiglobal(s1, s2, Scoring::BUBBLE);
+        let fs = super::semiglobal(s1, s2, Scoring::BUBBLE);
+        let pc: Vec<(u32, u8)> = ps.ops.iter().map(|&(n, t)| (n as u32, t)).collect();
+        let fc: Vec<(u32, u8)> = fs.ops.iter().map(|&(n, t)| (n as u32, t)).collect();
+        let (bw, bg) = (bubble_verdict(&pc), bubble_verdict(&fc));
+        if bw {
+            b_pops += 1;
+        }
+        if bw == bg {
+            b_agree += 1;
+        } else {
+            b_disagree += 1;
+            if examples.len() < 10 {
+                examples.push(format!(
+                    "    bubble: len1={} len2={} scalar={bw} ffi={bg}",
+                    s1.len(),
+                    s2.len()
+                ));
+            }
+        }
+        if ps.score == fs.score {
+            score_eq += 1;
+        }
+        if ps.cigar == fs.cigar {
+            cigar_eq += 1;
+        }
+    }
+
+    let n = cases.len();
+    let pct = |k: usize| 100.0 * k as f64 / n as f64;
+    println!(
+        "parasail-ffi oracle: {n} cases\n  \
+         merge verdicts:  {m_agree} agree, {m_disagree} disagree ({m_merges} merge)\n  \
+         bubble verdicts: {b_agree} agree, {b_disagree} disagree ({b_pops} pop)\n  \
+         score==scalar:   {score_eq} ({:.1}%)\n  \
+         cigar==scalar:   {cigar_eq} ({:.1}%)",
+        pct(score_eq),
+        pct(cigar_eq)
+    );
+    for e in &examples {
+        println!("{e}");
+    }
+    assert_eq!(m_disagree, 0, "merge verdicts must not change");
+    assert_eq!(b_disagree, 0, "bubble verdicts must not change");
+}

--- a/rust/src/simplify.rs
+++ b/rust/src/simplify.rs
@@ -934,7 +934,7 @@ impl Consensus for SpoaParasail {
                 .then(|| crate::wfa::semiglobal(s1, s2, crate::parasail::Scoring::BUBBLE))
                 .flatten()
                 .unwrap_or_else(|| {
-                    crate::parasail::semiglobal(s1, s2, crate::parasail::Scoring::BUBBLE)
+                    crate::parasail::semiglobal_exact(s1, s2, crate::parasail::Scoring::BUBBLE)
                 })
         };
         a.ops.iter().map(|&(len, op)| (len as u32, op)).collect()

--- a/rust/tests/aligner_speed.rs
+++ b/rust/tests/aligner_speed.rs
@@ -1,0 +1,169 @@
+//! Wall-clock and agreement for the three alignment backends, on recorded calls.
+//!
+//! The question is not which aligner is fastest in the abstract --- it is which
+//! one is fastest *on the alignments isONform actually performs*, and what it
+//! costs in agreement with the reference. Both halves matter: WFA2 is faster
+//! than the scalar port and disagrees; the linked C library is faster still and
+//! cannot disagree, because it is what the reference calls.
+//!
+//! ```text
+//! PARASAIL_CASES=<recorded calls> cargo test --release --test aligner_speed -- --nocapture
+//! ```
+//!
+//! Record the cases with `bench/dump_reference.py --record-parasail`. Use a
+//! corpus of *corrected* reads: the sequences being aligned are consensuses, and
+//! their length is what decides the ratio. `bench/corpus/sirv_small` yields
+//! ~200 bp; a real corpus yields ~600 bp with a 1 kb tail, and the backends do
+//! not rank the same way on both.
+
+use isonform::parasail::Scoring;
+use std::time::Instant;
+
+struct Case {
+    s1: Vec<u8>,
+    s2: Vec<u8>,
+    cigar: String,
+    score: i32,
+    sc: Scoring,
+}
+
+fn load(path: &str) -> Vec<Case> {
+    let text = std::fs::read_to_string(path).expect("read PARASAIL_CASES");
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() < 8 {
+            continue;
+        }
+        let (s1, s2) = (f[0].as_bytes().to_vec(), f[1].as_bytes().to_vec());
+        if s1.is_empty() || s2.is_empty() {
+            continue;
+        }
+        out.push(Case {
+            s1,
+            s2,
+            cigar: f[2].to_string(),
+            score: f[3].parse().expect("score"),
+            sc: Scoring {
+                match_score: f[4].parse().expect("match"),
+                mismatch: f[5].parse().expect("mismatch"),
+                open: f[6].parse().expect("open"),
+                ext: f[7].parse().expect("ext"),
+            },
+        });
+    }
+    out
+}
+
+/// Best of `repeats`, after one warm-up pass. Returns (millis, cigar hits,
+/// score hits) against the *recorded reference* answer.
+fn time_backend(
+    cases: &[Case],
+    repeats: usize,
+    f: &dyn Fn(&Case) -> (i32, String),
+) -> (f64, usize, usize) {
+    for c in cases {
+        std::hint::black_box(f(c));
+    }
+    let (mut cigar_hits, mut score_hits) = (0usize, 0usize);
+    let mut best = f64::MAX;
+    for r in 0..repeats {
+        let t = Instant::now();
+        let (mut ch, mut sh) = (0usize, 0usize);
+        for c in cases {
+            let (score, cigar) = f(c);
+            if cigar == c.cigar {
+                ch += 1;
+            }
+            if score == c.score {
+                sh += 1;
+            }
+            std::hint::black_box(score);
+        }
+        best = best.min(t.elapsed().as_secs_f64() * 1000.0);
+        if r == 0 {
+            cigar_hits = ch;
+            score_hits = sh;
+        }
+    }
+    (best, cigar_hits, score_hits)
+}
+
+#[test]
+fn the_three_backends_measured_on_recorded_calls() {
+    let Ok(path) = std::env::var("PARASAIL_CASES") else {
+        eprintln!("SKIPPED: set PARASAIL_CASES to the recorded calls");
+        return;
+    };
+    let repeats: usize = std::env::var("ALIGNER_BENCH_REPEATS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+    let cases = load(&path);
+    assert!(!cases.is_empty(), "no usable cases in {path}");
+
+    let mut lens: Vec<usize> = cases.iter().map(|c| c.s1.len().max(c.s2.len())).collect();
+    lens.sort_unstable();
+    let at = |q: f64| lens[((lens.len() - 1) as f64 * q) as usize];
+    println!(
+        "{} cases  maxlen median={} p90={} max={}",
+        cases.len(),
+        at(0.5),
+        at(0.9),
+        at(1.0)
+    );
+
+    let scalar = time_backend(&cases, repeats, &|c| {
+        let a = isonform::parasail::semiglobal(&c.s1, &c.s2, c.sc);
+        (a.score, a.cigar)
+    });
+    let wfa = time_backend(&cases, repeats, &|c| {
+        match isonform::wfa::semiglobal(&c.s1, &c.s2, c.sc) {
+            Some(a) => (a.score, a.cigar),
+            // Exactly what the call site does when WFA2 declines.
+            None => {
+                let a = isonform::parasail::semiglobal(&c.s1, &c.s2, c.sc);
+                (a.score, a.cigar)
+            }
+        }
+    });
+
+    println!(
+        "\n{:<38}{:>10}{:>10}{:>14}{:>14}",
+        "backend", "wall(ms)", "speedup", "cigar==ref", "score==ref"
+    );
+    let row = |name: &str, (ms, ch, sh): (f64, usize, usize)| {
+        println!(
+            "{:<38}{:>10.1}{:>9.2}x{:>9} {:>3.1}%{:>9} {:>3.1}%",
+            name,
+            ms,
+            scalar.0 / ms,
+            ch,
+            100.0 * ch as f64 / cases.len() as f64,
+            sh,
+            100.0 * sh as f64 / cases.len() as f64
+        )
+    };
+    row("parasail (scalar port)", scalar);
+    row("WFA2 (+ parasail fallback)", wfa);
+    #[cfg(feature = "parasail-ffi")]
+    {
+        let ffi = time_backend(&cases, repeats, &|c| {
+            let a = isonform::parasail_ffi::semiglobal(&c.s1, &c.s2, c.sc);
+            (a.score, a.cigar)
+        });
+        row("parasail C (libparasail-sys)", ffi);
+        // Not a benchmark assertion --- an identity one. If this backend ever
+        // stops reproducing the recorded reference exactly, it is not calling
+        // what we think it is, and the speed is beside the point.
+        assert_eq!(
+            ffi.1,
+            cases.len(),
+            "the linked library must reproduce every recorded CIGAR"
+        );
+        assert_eq!(ffi.2, cases.len(), "...and every recorded score");
+    }
+}


### PR DESCRIPTION
Adds parasail's own C library as an alignment backend, behind a default `parasail-ffi` feature with a pure-Rust fallback (`--no-default-features`).

**`--faithful` gets faster for free.** The exact path now calls the same C library the reference does, so output cannot move: 2.9x the Python implementation on `sirv_real` where it was 1.3x, 3.2x on `pacbio_sirv` where it was 2.4x. Byte-identity re-verified on all four end-to-end comparisons, and again with `ISONFORM_PARASAIL_FFI=0` forcing the scalar path.

**The default aligner does not change.** On ONT data the linked library beats WFA2 on speed, memory and accuracy; on PacBio HiFi it is 1.2x slower and needs 2.1x the memory, so WFA2 stays default and `ISONFORM_WFA2=0` selects parasail. Full three-corpus measurement in Port-benchmark.md, *The third aligner*.

**Correctness is gated on verdicts, not CIGARs** (PORTING.md finding 41): 350 460 recorded calls, 0 disagreements on both the merge and bubble booleans, 100% score and CIGAR agreement.

CI now builds, tests and lints `--no-default-features` as well, so the no-cmake path cannot rot.