### PR TITLE
Correct and trim the port docs

### DIFF
--- a/Port-benchmark.md
+++ b/Port-benchmark.md
@@ -20,8 +20,9 @@ only wall clock varies.
 **port (default)** is the shipped configuration: faithful plus the WFA2 aligner.
 **port (parasail-C)** is `ISONFORM_WFA2=0`: the default configuration with
 parasail's own C library in place of WFA2 --- see *The third aligner* below.
-The faithful and parasail-C rows in *Speed and memory* predate that backend and
-are the pure-Rust reimplementation; *The third aligner* re-measures both.
+The `port (faithful)` column in *Speed and memory* below predates that backend
+and is the pure-Rust reimplementation, so it understates faithful mode on every
+row; *The third aligner* re-measures it on the three corpora it was re-run on.
 
 **Poly-A tails are trimmed from isoforms before matching.** The SIRV reference
 transcripts are annotated without one; cDNA has one. Untrimmed, those bases are
@@ -107,6 +108,11 @@ in:
 | `droso_deep` | 11 440.4s · 2 733 MB | 6 187.5s (1.8x) · 1 666 MB | **1 312.6s (8.7x)** · 1 810 MB |
 | `pacbio_sirv` | 7 108.0s · 8 316 MB | 3 002.2s (2.4x) · 4 968 MB | **141.4s (50.3x)** · 3 957 MB |
 | `pacbio_droso` | not run | 27 029.9s · 4 505 MB | **1 264.9s (21.4x*)** · 3 515 MB |
+
+The `port (faithful)` column is the pure-Rust parasail. Linking parasail's C
+library makes that configuration 1.4--2.3x faster again without changing its
+output --- measured on three of these corpora in *The third aligner*; the rest
+of this column has not been re-run.
 
 * `pacbio_droso` has no Python benchmark: Python took 7 108s on `pacbio_sirv`, a corpus
 26x smaller, so the run was not attempted. The 21.4x on that row is the default

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ port is checked against; see [INSTALL-python.md](INSTALL-python.md).
 
 ### Rust-port versions
 
-By default the Rust port uses the WFA2 aligner: **4–10×** faster than the Python 
+By default the Rust port uses the WFA2 aligner: **5–11×** faster than the Python 
 implementation on ONT data and **~50×** on PacBio HiFi, at comparable accuracy, 
 though it does not produce identical output.
 
 The `--faithful` parameter reproduces the python implementation byte for byte, at
-about **3×** the Python implementation. We recommend using the port in default
+about **2–3×** the Python implementation. We recommend using the port in default
 mode (no `--faithful` flag).
 
 A third aligner is available: `ISONFORM_WFA2=0` uses parasail's own C library

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 ## Installation <a name="installation"></a>
 
-It needs a Rust toolchain ([rustup.rs](https://rustup.rs)), plus `cmake` and
-`libclang` to build the bundled C aligners.
+It needs a Rust toolchain ([rustup.rs](https://rustup.rs)), `cmake` and `libclang`.
 
 ```
 git clone https://github.com/aljpetri/isONform.git
@@ -17,34 +16,24 @@ cargo build --release
 
 That produces `target/release/isONform_parallel` and `target/release/main`. Put
 them on your `PATH` and run them as shown under
-[Running isONform](#Running).
-
-If `cmake` or `libclang` is not available, `cargo build --release
---no-default-features` builds without linking parasail's C library and falls
-back to a pure-Rust implementation of it. Output is identical either way; the
-fallback is slower.
+[Running isONform](#Running). Without `cmake` or `libclang`, add
+`--no-default-features`: same output, slower.
 
 The original python implementation is still available and is the reference this
 port is checked against; see [INSTALL-python.md](INSTALL-python.md).
 
 ### Rust-port versions
 
-By default the Rust port uses the WFA2 aligner: **5–11×** faster than the Python 
-implementation on ONT data and **~50×** on PacBio HiFi, at comparable accuracy, 
-though it does not produce identical output.
+By default the Rust port is **5–11×** faster than the python implementation on
+ONT data and **~50×** on PacBio HiFi, at comparable accuracy, though it does not
+produce identical output.
 
-The `--faithful` parameter reproduces the python implementation byte for byte, at
-about **2–3×** the Python implementation. We recommend using the port in default
-mode (no `--faithful` flag).
+`--faithful` reproduces the python implementation byte for byte, at about
+**2–3×** its speed. We recommend the default (no `--faithful` flag).
 
-A third aligner is available: `ISONFORM_WFA2=0` uses parasail's own C library
-instead of WFA2. On ONT data it is faster than the default, uses less memory and
-is closer to the Python implementation's output; on PacBio HiFi it is slower and
-needs about twice the memory. See [Port-benchmark.md](Port-benchmark.md).
-
-Full comparison against the python implementation --- accuracy,
-redundancy, runtime and peak memory on five corpora from 10 000 to 1 000 000 reads
-are found here: [Port-benchmark.md](Port-benchmark.md).
+Full comparison --- accuracy, redundancy, runtime and peak memory on seven
+corpora from 10 000 to 1 000 000 reads, and the aligner the two modes use ---
+is in [Port-benchmark.md](Port-benchmark.md).
 
 ### Running a test <a name="runtest"></a>
 


### PR DESCRIPTION
Follow-up to #30, docs only.

**Two figures were overstated.** The README's ONT speedup had been changed to 4–10× on the strength of a single droso run that happened to be slower than the one in the benchmark table — that was not a re-measurement, so it goes back to 5–11×, which is what the table says. Faithful mode is given as 2–3×, which is what was actually measured (2.02× droso, 2.94× `sirv_real`, 3.21× `pacbio_sirv`).

`Port-benchmark.md`'s definitions referred to "parasail-C rows in *Speed and memory*", and that table has no such column. It now says plainly that its `port (faithful)` column predates the linked backend and understates every row — only three of the seven corpora were re-run.

**The README is shorter.** Two modes is what a user has to choose between; which aligner backs each one is not install information. The `ISONFORM_WFA2=0` paragraph is gone from the README and stays in `Port-benchmark.md`'s *The third aligner*, which the README links to. Requirements and the `--no-default-features` escape hatch are one line each now. Install and versions go from 40 lines to 31.

The escape hatch itself stays: `libparasail-sys` pulls `bindgen`, so `libclang` is a new hard build requirement and a build without it fails outright.

Also corrects "five corpora" to seven.
