### PR TITLE
README: point at isONpipe for the full pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # isONform - Reference-free isoform reconstruction from long read sequencing data
 
+**Doing de novo transcriptome reconstruction?** isONclust, isONcorrect and isONform are one
+workflow — [isONpipe](https://github.com/ksahlin/isONpipe) installs all three and runs them
+with one command.
+
 ### isONform has been re-implemented in Rust (2026-09-04) and is 5-50x faster (see below).
 
 
@@ -69,16 +73,14 @@ Argument names, defaults, validation messages and exit codes match the python
 implementation, so any existing command or script works unchanged. Add
 `--faithful` to reproduce the python output byte for byte.
 
-The full isON-pipeline (isONclust, isONcorrect, isONform) can be found [here](https://github.com/aljpetri/isONform/blob/master/isON_pipeline.sh) and is run via:
+### The full pipeline
+
+[isONpipe](https://github.com/ksahlin/isONpipe) installs isONclust, isONcorrect and isONform and
+runs all three:
 
 ```
-./isON_pipeline.sh --raw_reads </absolute/path/to/raw_reads.fq>  --outfolder <outfolder>  --num_cores <num_cores> --isONform_folder <isONform_folder> --iso_abundance <iso_abundance> --mode <mode>
-```
-(Please note that this requires isONclust [LINK](https://github.com/ksahlin/isONclust) and isONcorrect [LINK](https://github.com/ksahlin/isONcorrect) to be installed in addition to isONform)
-
-To receive more information about the arguments used for the isON_pipeline script:
-```
-./isON_pipeline.sh --help
+isONpipe install
+isONpipe run --reads reads.fq --outfolder out --t 16
 ```
 
 ## Outputs <a name="Outputs"></a>


### PR DESCRIPTION
The three tools are one workflow, and the README did not say where the other two live.

**Banner** under the title, matching the one now in isONclust and isONcorrect:

> **Doing de novo transcriptome reconstruction?** isONclust, isONcorrect and isONform are one workflow — [isONpipe](https://github.com/ksahlin/isONpipe) installs all three and runs them with one command.

**"The full pipeline"** replaces the `isON_pipeline.sh` invocation. The script needs isONclust, isONcorrect and isONform installed separately and an `--isONform_folder` to find this one — a lot of setup before a first result. [isONpipe](https://github.com/ksahlin/isONpipe) builds all three from source into one folder and runs them with the same stage order and the same isONform parameters this script passes (`--k 20 --w 31 --xmin 14 --xmax 80 --delta_len 10 --max_seqs_to_spoa 200 --exact_instance_limit 50 --delta_iso_len_3 30 --delta_iso_len_5 50`), so a run through it is the run this script did:

```
isONpipe install
isONpipe run --reads reads.fq --outfolder out --t 16
```

It also has `--mode pacbio`, `--from`/`--to` to resume a stage, `--dry_run`, per-stage logs, and passthrough arguments to every parameter of all three tools. Its CI installs the tools from their release tags on every push and from the three `master` branches weekly, so a change here that breaks the pipeline shows up there.

`isON_pipeline.sh` is untouched and still in the repository — this is a README change, not a removal. Happy to keep a line pointing at the script if you would rather not drop the mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
